### PR TITLE
Rename pkg_expose to pkg_exposes & add pkg_exports snippet

### DIFF
--- a/grammars/habitat.cson
+++ b/grammars/habitat.cson
@@ -10,7 +10,7 @@
 ]
 'patterns': [
   {
-    'match': 'pkg_(?:name|origin|version|maintainer|license|source|filename|shasum|deps|build_deps|dirname|lib_dirs|include_dirs|distname|bin_dirs|pconfig_dirs|svc_run|expose|interpreters|svc_user|svc_group|description|upstream_url)'
+    'match': 'pkg_(?:name|origin|version|maintainer|license|source|filename|shasum|deps|build_deps|dirname|lib_dirs|include_dirs|distname|bin_dirs|pconfig_dirs|svc_run|exports|exposes|interpreters|svc_user|svc_group|description|upstream_url)'
     'name': 'keyword.habitat.plans'
   }
   {

--- a/snippets/plans.cson
+++ b/snippets/plans.cson
@@ -89,12 +89,18 @@
   'pkg_svc_run (short)':
     'prefix': 'psr'
     'body': 'pkg_svc_run="${1:bin/haproxy} ${2:-f} ${3:\\$pkg_svc_config_path/haproxy.conf}"\n'
-  'pkg_expose':
-    'prefix': 'pkg_expose'
-    'body': 'pkg_expose=(${1:80} ${2:443})\n'
-  'pkg_expose (short)':
+  'pkg_exports':
+    'prefix': 'pkg_exports'
+    'body': "pkg_exports=(\n\t[${1}]=${2}\n\t)"
+  'pkg_exports (short)':
+    'prefix': 'px'
+    'body': "pkg_exports=(\n\t[${1}]=${2}\n)"
+  'pkg_exposes':
+    'prefix': 'pkg_exposes'
+    'body': 'pkg_exposes=(${1})\n'
+  'pkg_exposes (short)':
     'prefix': 'pe'
-    'body': 'pkg_expose=(${1:80} ${2:443})\n'
+    'body': 'pkg_exposes=(${1})\n'
   'pkg_interpreters':
     'prefix': 'pkg_interpreters'
     'body': 'pkg_interpreters=(${1:bin/bash})\n'


### PR DESCRIPTION
* Rename pkg_expose to pkg_exposes
* Remove default values for pkg_exposes snippet. These are no longer
  numeric literals and we can't easily provide a sensible default
* Add pkg_exports snippet

See these PRs in the Habitat repository for details:
* https://github.com/habitat-sh/habitat/pull/1712
* https://github.com/habitat-sh/habitat/pull/1667